### PR TITLE
Update README.md to fix script-name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ zef as a user, so you can choose to use the local or the global zef setup
 to install modules:
 
 ```
-install_zef_as_user: install Zef as ~/.perl6/bin/zef
+install-zef-as-user # install Zef as ~/.perl6/bin/zef
 ```
 
 ## Building your own packages


### PR DESCRIPTION
The local-install script for zef is incorrectly spelled (underscores where dashes go).  I also think the description of what the script is doing should be commented so that copying the line will still work in shell.