### PR TITLE
Deb copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,30 @@ $ bin/create-baseimg.p6 18.04
 You need to supply the necessary environment variables to Docker:
 
 ```bash
-$ docker run -ti --rm -v /var/tmp:/staging -e RAKUDO_VERSION=$RAKUDO_URL -e NQP_VERSION=$NQP_VERSION -e MOARVM_VERSION=$MOARVM_VERSION -e REVISION:$REVISION -e OS=$OS -e RELEASE=$RELEASE -e ARCH=$ARCH -e MAINTAINER=$MAINTAINER nxadm/rakudo-pkg:$TAG
+docker run -ti --rm -v /var/tmp:/staging \
+	-e RAKUDO_VERSION=$RAKUDO_VERSION \
+	-e NQP_VERSION=$NQP_VERSION \
+	-e MOARVM_VERSION=$MOARVM_VERSION \
+	-e REVISION=$REVISION \
+	-e OS=$OS \
+	-e RELEASE=$RELEASE \
+	-e ARCH=$ARCH \
+	-e MAINTAINER=$MAINTAINER \
+	nxadm/rakudo-pkg:$TAG
+```
+
+Some sample values:
+
+```bash
+RAKUDO_VERSION=2018.11
+NQP_VERSION=2018.11
+MOARVM_VERSION=2018.11
+REVISION=1
+OS=Debian
+RELEASE=9
+ARCH=amd64
+MAINTAINER=john.doe@example.com
+TAG=debian-amd64-9
 ```
 
 ## Other Rakudo Distributions

--- a/docker/Dockerfile-alpine-x86_64-3.6
+++ b/docker/Dockerfile-alpine-x86_64-3.6
@@ -31,5 +31,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-alpine-x86_64-3.7
+++ b/docker/Dockerfile-alpine-x86_64-3.7
@@ -31,5 +31,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-alpine-x86_64-3.8
+++ b/docker/Dockerfile-alpine-x86_64-3.8
@@ -31,5 +31,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-centos-x86_64-7
+++ b/docker/Dockerfile-centos-x86_64-7
@@ -24,5 +24,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-debian-amd64-8
+++ b/docker/Dockerfile-debian-amd64-8
@@ -23,5 +23,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-debian-amd64-9
+++ b/docker/Dockerfile-debian-amd64-9
@@ -23,5 +23,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-fedora-x86_64-27
+++ b/docker/Dockerfile-fedora-x86_64-27
@@ -21,5 +21,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-fedora-x86_64-28
+++ b/docker/Dockerfile-fedora-x86_64-28
@@ -21,5 +21,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-fedora-x86_64-29
+++ b/docker/Dockerfile-fedora-x86_64-29
@@ -21,5 +21,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-opensuse-x86_64-15.0
+++ b/docker/Dockerfile-opensuse-x86_64-15.0
@@ -18,5 +18,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-opensuse-x86_64-42.3
+++ b/docker/Dockerfile-opensuse-x86_64-42.3
@@ -18,5 +18,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-ubuntu-amd64-14.04
+++ b/docker/Dockerfile-ubuntu-amd64-14.04
@@ -23,5 +23,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-ubuntu-amd64-16.04
+++ b/docker/Dockerfile-ubuntu-amd64-16.04
@@ -23,5 +23,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-ubuntu-amd64-18.04
+++ b/docker/Dockerfile-ubuntu-amd64-18.04
@@ -23,5 +23,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-ubuntu-amd64-18.10
+++ b/docker/Dockerfile-ubuntu-amd64-18.10
@@ -23,5 +23,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-ubuntu-i386-16.04
+++ b/docker/Dockerfile-ubuntu-i386-16.04
@@ -25,5 +25,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-ubuntu-i386-18.04
+++ b/docker/Dockerfile-ubuntu-i386-18.04
@@ -25,5 +25,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/Dockerfile-ubuntu-i386-18.10
+++ b/docker/Dockerfile-ubuntu-i386-18.10
@@ -25,5 +25,6 @@ COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
 COPY rakudo-pkg.sh /etc/profile.d/
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/EOL/Dockerfile-fedora-amd64-25
+++ b/docker/EOL/Dockerfile-fedora-amd64-25
@@ -17,6 +17,7 @@ gem install fpm && \
 dnf -q remove -y ${pkgs_tmp} && dnf -q clean all
 
 COPY pkg_rakudo.pl /
+COPY copyright /
 COPY install-zef-as-user /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/EOL/Dockerfile-fedora-x86_64-26
+++ b/docker/EOL/Dockerfile-fedora-x86_64-26
@@ -20,6 +20,7 @@ COPY pkg_rakudo.pl /
 COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
+COPY copyright /
 COPY rakudo-pkg.sh /etc/profile.d/
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/EOL/Dockerfile-pkgrakudo-ubuntu-amd64-16.10
+++ b/docker/EOL/Dockerfile-pkgrakudo-ubuntu-amd64-16.10
@@ -19,5 +19,6 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /*.deb /MoarVM* /nqp* /rakudo*
 
 COPY pkg_rakudo.pl /
 COPY install-zef-as-user /
+COPY copyright /
 
 CMD '/pkg_rakudo.pl'

--- a/docker/EOL/Dockerfile-pkgrakudo-ubuntu-i386-16.10
+++ b/docker/EOL/Dockerfile-pkgrakudo-ubuntu-i386-16.10
@@ -22,5 +22,6 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /*.deb /MoarVM* /nqp* /rakudo*
 
 COPY pkg_rakudo.pl /
 COPY install-zef-as-user /
+COPY copyright /
 
 CMD '/pkg_rakudo.pl'

--- a/docker/EOL/Dockerfile-ubuntu-amd64-17.04
+++ b/docker/EOL/Dockerfile-ubuntu-amd64-17.04
@@ -20,5 +20,6 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /*.deb /MoarVM* /nqp* /rakudo*
 
 COPY pkg_rakudo.pl /
 COPY install-zef-as-user /
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/EOL/Dockerfile-ubuntu-amd64-17.10
+++ b/docker/EOL/Dockerfile-ubuntu-amd64-17.10
@@ -21,6 +21,7 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /*.deb /MoarVM* /nqp* /rakudo*
 COPY pkg_rakudo.pl /
 COPY install-zef-as-user /
 COPY fix_windows10 /
+COPY copyright /
 COPY add-perl6-to-path /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/EOL/Dockerfile-ubuntu-i386-17.04
+++ b/docker/EOL/Dockerfile-ubuntu-i386-17.04
@@ -22,5 +22,6 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /*.deb /MoarVM* /nqp* /rakudo*
 
 COPY pkg_rakudo.pl /
 COPY install-zef-as-user /
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/EOL/Dockerfile-ubuntu-i386-17.10
+++ b/docker/EOL/Dockerfile-ubuntu-i386-17.10
@@ -24,5 +24,6 @@ COPY pkg_rakudo.pl /
 COPY install-zef-as-user /
 COPY fix_windows10 /
 COPY add-perl6-to-path /
+COPY copyright /
 
 ENTRYPOINT [ "/pkg_rakudo.pl" ]

--- a/docker/copyright
+++ b/docker/copyright
@@ -1,0 +1,244 @@
+Rakudo and NQP are both distributed under the Artistic License 2.0.
+MoarVM is licensed under the Artistic License 2.0, with some parts
+redistributed under other licenses.  See below for details.
+
+### LICENSE-Artistic-2.0
+
+		       The Artistic License 2.0
+
+	    Copyright (c) 2000-2006, The Perl Foundation.
+
+     Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+
+Preamble
+
+This license establishes the terms under which a given free software
+Package may be copied, modified, distributed, and/or redistributed.
+The intent is that the Copyright Holder maintains some artistic
+control over the development of that Package while still keeping the
+Package available as open source and free software.
+
+You are always permitted to make arrangements wholly outside of this
+license directly with the Copyright Holder of a given Package.  If the
+terms of this license do not permit the full use that you propose to
+make of the Package, you should contact the Copyright Holder and seek
+a different licensing arrangement. 
+
+Definitions
+
+    "Copyright Holder" means the individual(s) or organization(s)
+    named in the copyright notice for the entire Package.
+
+    "Contributor" means any party that has contributed code or other
+    material to the Package, in accordance with the Copyright Holder's
+    procedures.
+
+    "You" and "your" means any person who would like to copy,
+    distribute, or modify the Package.
+
+    "Package" means the collection of files distributed by the
+    Copyright Holder, and derivatives of that collection and/or of
+    those files. A given Package may consist of either the Standard
+    Version, or a Modified Version.
+
+    "Distribute" means providing a copy of the Package or making it
+    accessible to anyone else, or in the case of a company or
+    organization, to others outside of your company or organization.
+
+    "Distributor Fee" means any fee that you charge for Distributing
+    this Package or providing support for this Package to another
+    party.  It does not mean licensing fees.
+
+    "Standard Version" refers to the Package if it has not been
+    modified, or has been modified only in ways explicitly requested
+    by the Copyright Holder.
+
+    "Modified Version" means the Package, if it has been changed, and
+    such changes were not explicitly requested by the Copyright
+    Holder. 
+
+    "Original License" means this Artistic License as Distributed with
+    the Standard Version of the Package, in its current version or as
+    it may be modified by The Perl Foundation in the future.
+
+    "Source" form means the source code, documentation source, and
+    configuration files for the Package.
+
+    "Compiled" form means the compiled bytecode, object code, binary,
+    or any other form resulting from mechanical transformation or
+    translation of the Source form.
+
+
+Permission for Use and Modification Without Distribution
+
+(1)  You are permitted to use the Standard Version and create and use
+Modified Versions for any purpose without restriction, provided that
+you do not Distribute the Modified Version.
+
+
+Permissions for Redistribution of the Standard Version
+
+(2)  You may Distribute verbatim copies of the Source form of the
+Standard Version of this Package in any medium without restriction,
+either gratis or for a Distributor Fee, provided that you duplicate
+all of the original copyright notices and associated disclaimers.  At
+your discretion, such verbatim copies may or may not include a
+Compiled form of the Package.
+
+(3)  You may apply any bug fixes, portability changes, and other
+modifications made available from the Copyright Holder.  The resulting
+Package will still be considered the Standard Version, and as such
+will be subject to the Original License.
+
+
+Distribution of Modified Versions of the Package as Source 
+
+(4)  You may Distribute your Modified Version as Source (either gratis
+or for a Distributor Fee, and with or without a Compiled form of the
+Modified Version) provided that you clearly document how it differs
+from the Standard Version, including, but not limited to, documenting
+any non-standard features, executables, or modules, and provided that
+you do at least ONE of the following:
+
+    (a)  make the Modified Version available to the Copyright Holder
+    of the Standard Version, under the Original License, so that the
+    Copyright Holder may include your modifications in the Standard
+    Version.
+
+    (b)  ensure that installation of your Modified Version does not
+    prevent the user installing or running the Standard Version. In
+    addition, the Modified Version must bear a name that is different
+    from the name of the Standard Version.
+
+    (c)  allow anyone who receives a copy of the Modified Version to
+    make the Source form of the Modified Version available to others
+    under
+		
+	(i)  the Original License or
+
+	(ii)  a license that permits the licensee to freely copy,
+	modify and redistribute the Modified Version using the same
+	licensing terms that apply to the copy that the licensee
+	received, and requires that the Source form of the Modified
+	Version, and of any works derived from it, be made freely
+	available in that license fees are prohibited but Distributor
+	Fees are allowed.
+
+
+Distribution of Compiled Forms of the Standard Version 
+or Modified Versions without the Source
+
+(5)  You may Distribute Compiled forms of the Standard Version without
+the Source, provided that you include complete instructions on how to
+get the Source of the Standard Version.  Such instructions must be
+valid at the time of your distribution.  If these instructions, at any
+time while you are carrying out such distribution, become invalid, you
+must provide new instructions on demand or cease further distribution.
+If you provide valid instructions or cease distribution within thirty
+days after you become aware that the instructions are invalid, then
+you do not forfeit any of your rights under this license.
+
+(6)  You may Distribute a Modified Version in Compiled form without
+the Source, provided that you comply with Section 4 with respect to
+the Source of the Modified Version.
+
+
+Aggregating or Linking the Package 
+
+(7)  You may aggregate the Package (either the Standard Version or
+Modified Version) with other packages and Distribute the resulting
+aggregation provided that you do not charge a licensing fee for the
+Package.  Distributor Fees are permitted, and licensing fees for other
+components in the aggregation are permitted. The terms of this license
+apply to the use and Distribution of the Standard or Modified Versions
+as included in the aggregation.
+
+(8) You are permitted to link Modified and Standard Versions with
+other works, to embed the Package in a larger work of your own, or to
+build stand-alone binary or bytecode versions of applications that
+include the Package, and Distribute the result without restriction,
+provided the result does not expose a direct interface to the Package.
+
+
+Items That are Not Considered Part of a Modified Version 
+
+(9) Works (including, but not limited to, modules and scripts) that
+merely extend or make use of the Package, do not, by themselves, cause
+the Package to be a Modified Version.  In addition, such works are not
+considered parts of the Package itself, and are not subject to the
+terms of this license.
+
+
+General Provisions
+
+(10)  Any use, modification, and distribution of the Standard or
+Modified Versions is governed by this Artistic License. By using,
+modifying or distributing the Package, you accept this license. Do not
+use, modify, or distribute the Package, if you do not accept this
+license.
+
+(11)  If your Modified Version has been derived from a Modified
+Version made by someone other than you, you are nevertheless required
+to ensure that your Modified Version complies with the requirements of
+this license.
+
+(12)  This license does not grant you the right to use any trademark,
+service mark, tradename, or logo of the Copyright Holder.
+
+(13)  This license includes the non-exclusive, worldwide,
+free-of-charge patent license to make, have made, use, offer to sell,
+sell, import and otherwise transfer the Package with respect to any
+patent claims licensable by the Copyright Holder that are necessarily
+infringed by the Package. If you institute patent litigation
+(including a cross-claim or counterclaim) against any party alleging
+that the Package constitutes direct or contributory patent
+infringement, then this Artistic License to you shall terminate on the
+date that such litigation is filed.
+
+(14)  Disclaimer of Warranty:
+THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
+LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### LICENSE-MoarVM
+
+Software Copyright and License
+
+This software is copyright 2012-2015 by Jonathan Worthington and others.
+
+The Artistic License 2.0 (see Artistic2.txt) applies to this project, but
+some portions are redistributed under other licenses and are marked as such.
+
+Unofficial summary of the intended application of the Artistic License 2.0:
+
+- All the source code is available for anyone to read and to submit patches.
+
+- You may "take" and re-use large portions of the source code at will.
+
+- There is a "Standard Version" of this software to protect its name and
+    namespace as it's used in redistributions by package maintainers.
+
+- "Downstream" package maintainers allow us to use their bug fixes/patches.
+
+- You may bundle it with software you sell, or you may link/embed it.
+
+- You may fork and release modified builds if you thoroughly rename it.
+
+-- 3rdparty/ license information
+
+- dynasm     MIT
+- dyncall    MIT
+- libtommath Public Domain
+- libuv      MIT,BSD,ISC
+- msinttypes MIT
+- sha1       Public Domain
+- tinymt     MIT
+- uthash.h   MIT
+- freebsd    MIT
+

--- a/docker/pkg_rakudo.pl
+++ b/docker/pkg_rakudo.pl
@@ -3,7 +3,7 @@ use warnings;
 use strict;
 use feature 'say';
 use File::Copy;
-use File::Path qw/remove_tree/;
+use File::Path qw/remove_tree make_path/;
 
 ### Variables ###
 my $install_root = '/opt/rakudo-pkg';
@@ -66,6 +66,10 @@ move('/fix_windows10', "$install_root/bin/") or die($!);
 move('/add-perl6-to-path', "$install_root/bin/") or die($!);
 symlink("$install_root/bin/perl6", "$install_root/bin/rakudo") or die($!);
 symlink("$install_root/bin/perl6", "$install_root/bin/raku") or die($!);
+if ($distro_info{$os}{format} eq 'deb') {
+    make_path('/usr/share/doc/rakudo-pkg');
+    move('/copyright', '/usr/share/doc/rakudo-pkg/copyright') or die($!);
+}
 pkg_fpm() or exit 1;
 say "Rakudo was succesfully packaged.";
 
@@ -172,6 +176,9 @@ sub pkg_fpm {
         '--architecture', $arch,
         $install_root, '/etc/profile.d/rakudo-pkg.sh'
     );
+    if ($distro_info{$os}{format} eq 'deb') {
+        push @cmd, '/usr/share/doc/rakudo-pkg/copyright';
+    }
     say "@cmd";
     system(@cmd) == 0 or return 0;
     # Add OS info to filename


### PR DESCRIPTION
Create `/usr/share/doc/rakudo-pkg/copyright`, per [Debian Policy §12.5](https://www.debian.org/doc/debian-policy/ch-docs.html#copyright-information):

> Every package must be accompanied by a verbatim copy of its copyright information and distribution license in the file `/usr/share/doc/package/copyright`. This file must neither be compressed nor be a symbolic link.

I've opened a PR to fpm to make this easier (https://github.com/jordansissel/fpm/pull/1577), but no PRs have been merged in fpm in a couple months, so it's nothing to wait on.