### PR TITLE
Do not spam $PATH

### DIFF
--- a/docker/rakudo-pkg.sh
+++ b/docker/rakudo-pkg.sh
@@ -1,2 +1,4 @@
-PATH=$PATH:/opt/rakudo-pkg/bin:/opt/rakudo-pkg/share/perl6/bin
-export PATH
+RAKUDO_PATHS=/opt/rakudo-pkg/bin:/opt/rakudo-pkg/share/perl6/bin
+if ! echo "$PATH" | /bin/grep -Eq "(^|:)$RAKUDO_PATHS($|:)" ; then
+    export PATH="$PATH:$RAKUDO_PATHS"
+fi


### PR DESCRIPTION
On some systems (Fedora) this is called from .bashrc and thus each time a shell is opened. This change prevents adding the path multiple times in such a case.