### PR TITLE
Fixes for 2019.07 release build

### DIFF
--- a/docker/pkg_rakudo.pl
+++ b/docker/pkg_rakudo.pl
@@ -142,9 +142,9 @@ sub install_global_zef {
     system(@cmd) == 0 or return 0;
     chdir('zef') or die($!);
     @cmd = ("$install_root/bin/perl6", '-Ilib', 'bin/zef',
-        '--install-to=perl', 'install', '.');
+        '--install-to=core', 'install', '.');
     system(@cmd) == 0 or return 0;
-    symlink("$install_root/share/perl6/bin/zef", "$install_root/bin/zef")
+    symlink("$install_root/share/perl6/core/bin/zef", "$install_root/bin/zef")
         or die($!);
     chdir('/') or die($!);
     remove_tree('/var/tmp/zef') or warn($!);


### PR DESCRIPTION
The current [Travis CI builds](https://travis-ci.org/nxadm/rakudo-pkg/builds/560209154) are failing due to the predefined CompUnit Repository 'perl' being renamed to 'core' in rakudo/rakudo@4d5b254e654d3ec07f90128c4e07314d70b95402