### PR TITLE
Add missing $ to export command

### DIFF
--- a/docker/install-zef-as-user
+++ b/docker/install-zef-as-user
@@ -3,8 +3,8 @@
 if [ -f /opt/rakudo-pkg/bin/zef ]; then
     /opt/rakudo-pkg/bin/zef --install-to=home install zef
     else zef --install-to=home install zef
-fi     
+fi
 
 echo "Don't forget to add '~/.raku/bin' to your PATH,"
 echo "e.g. by adding this to .profile:"
-echo "export PATH=~/.raku/bin:PATH"
+echo "export PATH=~/.raku/bin:\$PATH"


### PR DESCRIPTION
The `export` example shown after installing `zef` is incorrect, and will lead to a `$PATH` that no longer includes most common locations for executables.